### PR TITLE
Set nickName, blocky, signerAddr in login saga, add selectors for blo…

### DIFF
--- a/app/containers/AccountProvider/reducer.js
+++ b/app/containers/AccountProvider/reducer.js
@@ -28,6 +28,9 @@ const initialState = fromJS({
   privKey: storageService.getItem('privKey'),
   email: storageService.getItem('email'),
   loggedIn: isLoggedIn(),
+  blocky: null,
+  nickName: null,
+  signerAddr: null,
   web3ReadyState: READY_STATE.CONNECTING,
   web3ErrMsg: null,
 });
@@ -42,7 +45,12 @@ function accountProviderReducer(state = initialState, action) {
     case WEB3_ERROR:
       return state.set('web3ErrMsg', action.err ? (action.err.message || 'Connection Error') : null);
     case ACCOUNT_LOADED:
-      return state.set('proxy', action.data.proxy).set('controller', action.data.controller).set('lastNonce', action.data.lastNonce);
+      return state.set('proxy', action.data.proxy)
+        .set('controller', action.data.controller)
+        .set('lastNonce', action.data.lastNonce)
+        .set('blocky', action.data.blocky)
+        .set('nickName', action.data.nickName)
+        .set('signerAddr', action.data.signer);
     case WEB3_METHOD_SUCCESS:
       return state.setIn(['web3', 'methods', action.key], fromJS(action.payload));
     case WEB3_METHOD_ERROR:
@@ -85,7 +93,10 @@ function accountProviderReducer(state = initialState, action) {
       if (!action.newAuthState.loggedIn) {
         newState = state
           .delete('privKey')
-          .delete('email');
+          .delete('email')
+          .set('blocky', null)
+          .set('nickName', null)
+          .set('signerAddr', null);
         storageService.removeItem('privKey');
         storageService.removeItem('email');
       } else {

--- a/app/containers/AccountProvider/sagas.js
+++ b/app/containers/AccountProvider/sagas.js
@@ -6,6 +6,8 @@ import fetch from 'isomorphic-fetch';
 import Raven from 'raven-js';
 
 import WebsocketProvider from '../../services/wsProvider';
+import { createBlocky } from '../../services/blockies';
+import { nickNameByAddress } from '../../services/nicknames';
 import {
   ethNodeUrl,
   ABI_TOKEN_CONTRACT,
@@ -204,9 +206,11 @@ function* accountLoginSaga() {
       const proxy = res[0];
       const controller = res[1];
       const lastNonce = res[2].toNumber();
+      const blocky = createBlocky(signer);
+      const nickName = nickNameByAddress(signer);
 
       // write data into the state
-      yield put(accountLoaded({ proxy, controller, lastNonce }));
+      yield put(accountLoaded({ proxy, controller, lastNonce, blocky, nickName, signer }));
 
       // start listen on the account controller for events
       // mostly auth errors

--- a/app/containers/AccountProvider/selectors.js
+++ b/app/containers/AccountProvider/selectors.js
@@ -12,6 +12,17 @@ const selectAccount = (state) => state.get('account');
 /**
  * Other specific selectors
  */
+
+const makeBlockySelector = () => createSelector(
+  selectAccount,
+  (account) => account.get('blocky'),
+);
+
+const makeNickNameSelector = () => createSelector(
+  selectAccount,
+  (account) => account.get('nickName'),
+);
+
 const makeSelectAccountData = () => createSelector(
   selectAccount,
   (account) => account.toJS()
@@ -19,6 +30,7 @@ const makeSelectAccountData = () => createSelector(
 
 const makeSignerAddrSelector = () => createSelector(
   selectAccount,
+  // (account) => account.get('signerAddr'),
   (account) => {
     if (account && account.get('privKey')) {
       const privKeyBuffer = new Buffer(account.get('privKey').replace('0x', ''), 'hex');
@@ -71,6 +83,8 @@ const makeSelectProxyAddr = () => createSelector(
 export default makeSelectAccountData;
 export {
   selectAccount,
+  makeBlockySelector,
+  makeNickNameSelector,
   makeSignerAddrSelector,
   makeSelectAccountData,
   makeSelectContract,

--- a/app/containers/AccountProvider/tests/reducer.test.js
+++ b/app/containers/AccountProvider/tests/reducer.test.js
@@ -8,6 +8,9 @@ describe('account reducer tests', () => {
     expect(accountProviderReducer(undefined, {}).toJS()).toEqual({
       privKey: undefined,
       email: undefined,
+      blocky: null,
+      nickName: null,
+      signerAddr: null,
       loggedIn: false,
       web3ReadyState: 0,
       web3ErrMsg: null,


### PR DESCRIPTION
…cky and nickname

Spent some personal time yesterday wrapping my head around immutableJS, redux and the way logins were being handled.

Any issues with setting these states from the saga? My main issue is that calling the createBlocky and nickNameByAddress functions in the components is making testing difficult. I think I could mock them with nock, but I'd rather have them stored in the redux state tree. Any issues with doing that?