### PR TITLE
Send create transaction through MetaMask if available

### DIFF
--- a/app/containers/AccountProvider/selectors.js
+++ b/app/containers/AccountProvider/selectors.js
@@ -69,6 +69,11 @@ const makeSelectPrivKey = () => createSelector(
   (account) => account.get('privKey')
 );
 
+const makeSelectInjected = () => createSelector(
+  selectAccount,
+  (account) => account.get('injected'),
+);
+
 const makeSelectHasWeb3 = () => createSelector(
   selectAccount,
   (account) => !!(account.get('isLocked') || account.get('injected'))
@@ -102,4 +107,5 @@ export {
   makeSelectWeb3ErrMsg,
   makeSelectHasWeb3,
   makeSelectNetworkSupported,
+  makeSelectInjected,
 };

--- a/app/containers/GeneratePage/index.js
+++ b/app/containers/GeneratePage/index.js
@@ -16,6 +16,7 @@ import { ErrorMessage } from '../../components/FormMessages';
 
 import * as accountService from '../../services/account';
 import * as storageService from '../../services/localStorage';
+import { makeSelectInjected, makeSelectNetworkSupported } from '../../containers/AccountProvider/selectors';
 import { getWeb3 } from '../../containers/AccountProvider/utils';
 import { waitForTx } from '../../utils/waitForTx';
 import { promisifyContractCall } from '../../utils/promisifyContractCall';
@@ -79,15 +80,37 @@ export class GeneratePage extends React.Component { // eslint-disable-line react
     this.setState({ entropySaved: true });
   }
 
-  handleCreate(wallet, receipt, confCode) {
+  createTx(wallet, receipt, confCode) {
+    const { injectedAccount, networkSupported } = this.props;
+    if (injectedAccount && networkSupported) {
+      const web3 = getWeb3(true);
+      const factory = web3.eth.contract(ABI_ACCOUNT_FACTORY).at(conf().accountFactory);
+      const create = promisifyContractCall(factory.create.sendTransaction);
+      return (
+        create(wallet.address, 0, { from: injectedAccount })
+          .then((txHash) => accountService.addWallet(confCode, wallet, txHash).then(() => txHash))
+      );
+    }
+
     return Promise.all([
       waitForAccountTxHash(wallet.address),
       accountService.addWallet(confCode, wallet),
-    ])
-      .catch(throwSubmitError)
-      .then(([txHash]) => {
-        this.props.onAccountTxHashReceived(txHash);
-        browserHistory.push('/login');
+    ]).then(([txHash]) => txHash);
+  }
+
+  handleCreate(wallet, receipt, confCode) {
+    return this.createTx(wallet, receipt, confCode)
+      .catch((err) => {
+        if (err.message.indexOf('Error: MetaMask Tx Signature') === -1) {
+          throwSubmitError(err);
+        }
+        return Promise.resolve();
+      })
+      .then((txHash) => {
+        if (txHash) {
+          this.props.onAccountTxHashReceived(txHash);
+          browserHistory.push('/login');
+        }
       });
   }
 
@@ -249,6 +272,8 @@ function mapDispatchToProps(dispatch) {
 const selector = formValueSelector('register');
 const mapStateToProps = (state) => ({
   entropy: selector(state, 'entropy'),
+  injectedAccount: makeSelectInjected()(state),
+  networkSupported: makeSelectNetworkSupported()(state),
 });
 
 // Wrap the component to inject dispatch and state into it

--- a/app/services/account.js
+++ b/app/services/account.js
@@ -39,10 +39,11 @@ export function confirm(sessionReceipt) {
   return request('post', 'confirm', { sessionReceipt });
 }
 
-export function addWallet(sessionReceipt, wallet) {
+export function addWallet(sessionReceipt, wallet, txHash) {
   return request('post', 'wallet', {
     sessionReceipt,
     wallet: JSON.stringify(wallet),
+    txHash,
   });
 }
 


### PR DESCRIPTION
I use metamask for tx if it enabled and on supported network, otherwise create tx will be sended on backend